### PR TITLE
Fix action tooltips overflowing outside of window

### DIFF
--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -388,8 +388,6 @@ const Koviko = {
       ul.koviko .ritual{color:#ff1493}
       ul.koviko .artifacts{color:#ffd700}
       ul.koviko .mind{color:#006400}
-      .actionOptions .showthis {width:max-content;bottom:100%;max-width:400px;margin-bottom:5px;}
-      .travelContainer, .actionContainer {position:relative;}
       \`;
       document.getElementById("actionsColumn").style.width="500px";
 


### PR DESCRIPTION
Commit e80a84a8a08a9a59d34fcdc46243e7a80878e93c caused a bug which makes action tooltips overflow outside of browser's window. To see this bug, resize the browser's window so that actions are close to the right edge and hover above one of the far right actions.

That commit moves action tooltips above the actions. Without the Predictor, they appear below the cursor. That change doesn't seem to be necessary for this extension.